### PR TITLE
Improve Save-Load File logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This template should help get you started developing with Tauri, React and Types
 - [Rustup](https://www.rust-lang.org/tools/install)
 - [Bun](https://bun.sh)
 
+[Prerequisite (Dev)](https://v2.tauri.app/start/prerequisites/#linux)
+
 ## How to run
 - `bun install`
 - `bun run tauri android init` (not required, only for android development)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4305,6 +4305,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-opener",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4302,6 +4302,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,4 +23,4 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2"
-
+tauri-plugin-fs = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+sha2 = "0.10"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,13 +2,6 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": [
-    "main"
-  ],
-  "permissions": [
-    "core:default",
-    "opener:default",
-    "dialog:default",
-    "dialog:default"
-  ]
+  "windows": ["main"],
+  "permissions": ["core:default", "opener:default", "dialog:default"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 use std::sync::Mutex;
-use tauri::{menu::{MenuBuilder, SubmenuBuilder}};
+use tauri::menu::{MenuBuilder, SubmenuBuilder};
 use tauri::Emitter;
 mod modules;
 
@@ -9,37 +9,47 @@ pub fn run() {
     use tauri::Manager;
     tauri::Builder::default()
         .setup(|app| {
-            app.manage(Mutex::new(modules::AppData { project_path: None, open_files: Vec::new() }));
+            app.manage(Mutex::new(modules::AppData {
+                project_path: None,
+                open_files: Vec::new(),
+            }));
             // TODO: Move menu and title bar to tsx.
             let file_menu = SubmenuBuilder::new(app, "File")
-                .text("save", "Save") 
+                .text("save", "Save")
                 .text("open_dir", "Open Folder")
                 .text("quit", "Quit")
                 .build()?;
-            let menu = MenuBuilder::new(app)
-            .items(&[&file_menu])
-            .build()?;
+            let menu = MenuBuilder::new(app).items(&[&file_menu]).build()?;
 
             app.set_menu(menu)?;
 
             app.on_menu_event(move |app_handle: &tauri::AppHandle, event| {
-                    match event.id().0.as_str() {
-                        "save" => {app_handle.clone().emit("save", "current").unwrap()},
-                        "open" => {let _ = modules::file_operations::load_file(app_handle.clone(), None); },
-                        "open_dir" => {let _ = modules::file_operations::open_directory(app_handle.clone()); },
-                        "quit" => {app_handle.clone().exit(0);},
-                        _ => eprintln!("unexpected menu event")
+                match event.id().0.as_str() {
+                    "save" => app_handle.clone().emit("save", "current").unwrap(),
+                    "open" => {
+                        // Dialog will be handled by frontend JavaScript
+                        app_handle.clone().emit("open-file-dialog", ()).unwrap();
                     }
+                    "open_dir" => {
+                        // Dialog will be handled by frontend JavaScript
+                        app_handle.clone().emit("open-folder-dialog", ()).unwrap();
+                    }
+                    "quit" => {
+                        app_handle.clone().exit(0);
+                    }
+                    _ => eprintln!("unexpected menu event"),
+                }
             });
 
             Ok(())
         })
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
-            modules::file_operations::save_file,
-            modules::file_operations::load_file,
-            modules::file_operations::open_directory,
+            modules::file_operations::save_file_to_path,
+            modules::file_operations::load_file_from_path,
+            modules::file_operations::set_project_directory,
             modules::file_operations::read_directory_contents
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,10 +9,10 @@ pub fn run() {
     use tauri::Manager;
     tauri::Builder::default()
         .setup(|app| {
-            app.manage(Mutex::new(modules::AppData { project_path: None }));
+            app.manage(Mutex::new(modules::AppData { project_path: None, open_files: Vec::new() }));
+            // TODO: Move menu and title bar to tsx.
             let file_menu = SubmenuBuilder::new(app, "File")
-                .text("save", "Save")
-                .text("open", "Open")
+                .text("save", "Save") 
                 .text("open_dir", "Open Folder")
                 .text("quit", "Quit")
                 .build()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,7 +24,7 @@ pub fn run() {
 
             app.on_menu_event(move |app_handle: &tauri::AppHandle, event| {
                     match event.id().0.as_str() {
-                        "save" => {app_handle.clone().emit("save", "").unwrap()},
+                        "save" => {app_handle.clone().emit("save", "current").unwrap()},
                         "open" => {let _ = modules::file_operations::load_file(app_handle.clone(), None); },
                         "open_dir" => {let _ = modules::file_operations::open_directory(app_handle.clone()); },
                         "quit" => {app_handle.clone().exit(0);},

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,7 +50,8 @@ pub fn run() {
             modules::file_operations::save_file_to_path,
             modules::file_operations::load_file_from_path,
             modules::file_operations::set_project_directory,
-            modules::file_operations::read_directory_contents
+            modules::file_operations::read_directory_contents,
+            modules::file_operations::is_dirty
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ pub fn run() {
         .setup(|app| {
             app.manage(Mutex::new(modules::AppData {
                 project_path: None,
-                open_files: Vec::new(),
+                opened_files: Vec::new(),
             }));
             // TODO: Move menu and title bar to tsx.
             let file_menu = SubmenuBuilder::new(app, "File")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,11 +9,8 @@ pub fn run() {
     use tauri::Manager;
     tauri::Builder::default()
         .setup(|app| {
-            app.manage(Mutex::new(modules::AppData {
-                project_path: None,
-                opened_files: Vec::new(),
-            }));
-            // TODO: Move menu and title bar to tsx.
+            app.manage(Mutex::new(modules::AppData { project_path: None }));
+
             let file_menu = SubmenuBuilder::new(app, "File")
                 .text("save", "Save")
                 .text("open_dir", "Open Folder")
@@ -23,22 +20,17 @@ pub fn run() {
 
             app.set_menu(menu)?;
 
-            app.on_menu_event(move |app_handle: &tauri::AppHandle, event| {
-                match event.id().0.as_str() {
-                    "save" => app_handle.clone().emit("save", "current").unwrap(),
-                    "open" => {
-                        // Dialog will be handled by frontend JavaScript
-                        app_handle.clone().emit("open-file-dialog", ()).unwrap();
-                    }
-                    "open_dir" => {
-                        // Dialog will be handled by frontend JavaScript
-                        app_handle.clone().emit("open-folder-dialog", ()).unwrap();
-                    }
-                    "quit" => {
-                        app_handle.clone().exit(0);
-                    }
-                    _ => eprintln!("unexpected menu event"),
+            app.on_menu_event(move |app_handle, event| match event.id().0.as_str() {
+                "save" => {
+                    let _ = app_handle.emit("save", ());
                 }
+                "open_dir" => {
+                    let _ = app_handle.emit("open-folder-dialog", ());
+                }
+                "quit" => {
+                    app_handle.exit(0);
+                }
+                _ => {}
             });
 
             Ok(())

--- a/src-tauri/src/modules/file_operations.rs
+++ b/src-tauri/src/modules/file_operations.rs
@@ -4,58 +4,13 @@ use std::fs::{read_dir, read_to_string, write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager};
-use tauri_plugin_dialog::{DialogExt, FilePath};
 
 use super::AppData;
 
-/// Save a file to machine
-/// 
-/// using file_path to determine whether using Tauri Dialog or save it to path specified from frontend. 
+/// Save a file to machine using the provided file path
 #[tauri::command]
-pub fn save_file(app: AppHandle, file_content: String, file_path: Option<String>) -> Result<String, String> {
-    return if file_path.is_none() {save_file_dialog(app, file_content)} else {save_file_path(file_content, file_path.unwrap())}
-}
-
-/// Save file via Dialog
-/// 
-/// Using Tauri Dialog to select location and file name to be saved to.
-fn save_file_dialog(app: AppHandle, file_content: String)  -> Result<String, String> {
-    let file_path = match app
-        .dialog()
-        .file()
-        .set_file_name("untitled")
-        .add_filter("Markdown", &["md", "markdown"])
-        .add_filter("Text File", &["txt"])
-        .blocking_save_file() 
-    {
-        Some(fp) => fp,
-        None => return Err("File save dialog was cancelled or failed.".to_string())
-    };
-
-    let path = match file_path.as_path() {
-        Some(p) => p,
-        None => return Err("File save dialog was cancelled or failed.".to_string())
-    };
-
-     let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("File")
-        .to_string();
-
-    let write_res = write(&path, file_content);    
-
-    match write_res {
-        Ok(_) => return Ok(format!("{} saved successfully", file_name)),
-        Err(e) => return Err(e.to_string()) 
-    }
-
-
-}
-
-/// Save file via the path given by string.
-fn save_file_path(file_content: String, path_str: String) -> Result<String, String> {
-    let path_buf = PathBuf::from(path_str);
+pub fn save_file_to_path(file_content: String, file_path: String) -> Result<String, String> {
+    let path_buf = PathBuf::from(file_path);
     let path = path_buf.as_path();
 
     let file_name = path
@@ -64,58 +19,19 @@ fn save_file_path(file_content: String, path_str: String) -> Result<String, Stri
         .unwrap_or("File")
         .to_string();
 
-    let write_res = write(&path, file_content);    
+    let write_res = write(&path, file_content);
 
     match write_res {
-        Ok(_) => return Ok(format!("{} saved successfully", file_name)),
-        Err(e) => return Err(e.to_string()) 
+        Ok(_) => Ok(format!("{} saved successfully", file_name)),
+        Err(e) => Err(e.to_string()),
     }
 }
 
-/// Tauri command to load file from machine.
-/// 
-/// Tauri command allows optionally path if path is passed, function will invoke load_path(), otherwise load_dialog()
+/// Load file from the specified path
 #[tauri::command]
-pub fn load_file(app: AppHandle, path: Option<String>) -> Result<(String, String, String), String> {
-    return if path.is_none() { load_dialog(app) } else { load_path(path.unwrap()) }
-}
-
-/// Open Tauri Dialog and load file content from it.
-/// 
-/// Using Tauri Dialog Plugin to allows user to pick the file from any user's machine to load contents from.
-fn load_dialog(app: AppHandle) -> Result<(String, String, String), String> {
-    let file_path = match app
-        .dialog()
-        .file()
-        .blocking_pick_file() 
-    {
-        Some(path) => path,
-        None => return Err("File dialog was cancelled or no file selected".to_string())
-    };
-    
-    let path = match file_path.as_path() {
-        Some(p) => p,
-        None => return Err("File dialog was cancelled or no file selected".to_string())
-    };
-
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("Unknown")
-        .to_string();
-    
-    let content = get_file_content(path).unwrap_or(String::from(""));
-    
-    Ok((file_name, path.to_str().unwrap().to_string(), content))
-}
-
-/// Load file form path
-/// 
-/// This function get use path string to get the file content from specified path
-fn load_path(path_str: String) -> Result<(String, String, String), String> {
-    
+pub fn load_file_from_path(path_str: String) -> Result<(String, String, String), String> {
     let path_buf = PathBuf::from(path_str);
-    let path =  path_buf.as_path();
+    let path = path_buf.as_path();
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -137,28 +53,16 @@ fn get_file_content(path: &Path) -> Option<String> {
     }
 }
 
+/// Set the project directory path (called from frontend after folder selection)
 #[tauri::command]
-pub fn open_directory(app: AppHandle) -> Result<(), String> {
-    let file_path: FilePath = match app
-        .dialog()
-        .file()
-        .blocking_pick_folder()
-         
-    {
-        Some(path) => path,
-        None => return Err("File dialog was cancelled or no file selected".to_string())
-    };
+pub fn set_project_directory(app: AppHandle, directory_path: String) -> Result<(), String> {
+    let path_buf = PathBuf::from(directory_path.clone());
 
-    let path = match file_path.as_path() {
-        Some(p) => p,
-        None => return Err("File dialog was cancelled or no file selected".to_string())
-    };
-
-    println!("Open folder: {}", path.display());
-    let state= app.state::<Mutex<AppData>>();
+    println!("Set project folder: {}", path_buf.display());
+    let state = app.state::<Mutex<AppData>>();
     let mut data = state.lock().unwrap();
-    data.project_path = Some(path.to_path_buf()); // Convert to PathBuf
-    app.emit("folder-selected", path.display().to_string()).unwrap();
+    data.project_path = Some(path_buf);
+    app.emit("folder-selected", directory_path).unwrap();
     Ok(())
 }
 
@@ -178,6 +82,6 @@ pub fn read_directory_contents(path: String) -> Result<Vec<(String, bool)>, Stri
             contents.push((file_name, is_dir));
         }
     }
-    
+
     Ok(contents)
 }

--- a/src-tauri/src/modules/file_operations.rs
+++ b/src-tauri/src/modules/file_operations.rs
@@ -1,123 +1,65 @@
-#![allow(dead_code)]
-
 use sha2::{Digest, Sha256};
 use std::fs::{read_dir, read_to_string, write};
-use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-use tauri::{AppHandle, Emitter, Manager};
+use std::path::PathBuf;
+use tauri::{AppHandle, Emitter};
 
-use super::AppData;
-
-/// Compute SHA256 hash of content (normalizes line endings)
+/// Compute SHA256 hash of content with normalized line endings (LF)
 fn compute_hash(content: &str) -> String {
     let mut hasher = Sha256::new();
-    // Normalize line endings to LF for consistent hashing
+    // Normalize all line endings to LF for consistent hashing
     let normalized = content.replace("\r\n", "\n");
-    hasher.update(&normalized);
+    hasher.update(normalized.as_bytes());
     format!("{:x}", hasher.finalize())
 }
 
-/// Save a file to machine using the provided file path
+/// Save a file to disk at the specified path
 #[tauri::command]
-pub fn save_file_to_path(
-    app: AppHandle,
-    file_content: String,
-    file_path: String,
-) -> Result<String, String> {
-    let path_buf = PathBuf::from(file_path);
-    let path = path_buf.as_path();
+pub fn save_file_to_path(file_content: String, file_path: String) -> Result<String, String> {
+    let path_buf = PathBuf::from(&file_path);
 
-    let file_name = path
+    write(&path_buf, &file_content).map_err(|e| e.to_string())?;
+
+    let file_name = path_buf
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("File")
         .to_string();
 
-    let write_res = write(&path, file_content.clone());
-
-    match write_res {
-        Ok(_) => {
-            // Update the file state in AppData
-            let state = app.state::<Mutex<AppData>>();
-            let mut data = state.lock().unwrap();
-
-            let hash = compute_hash(&file_content);
-
-            // Update existing entry or add new one
-            if let Some(entry) = data
-                .opened_files
-                .iter_mut()
-                .find(|(file_path, _)| file_path == &path_buf)
-            {
-                entry.1 = hash;
-            } else {
-                data.opened_files.push((path_buf, hash));
-            }
-
-            Ok(format!("{} saved successfully", file_name))
-        }
-        Err(e) => Err(e.to_string()),
-    }
+    Ok(format!("{} saved successfully", file_name))
 }
 
 /// Load file from the specified path
 #[tauri::command]
-pub fn load_file_from_path(
-    app: AppHandle,
-    path_str: String,
-) -> Result<(String, String, String), String> {
-    let path_buf = PathBuf::from(path_str);
-    let path = path_buf.as_path();
-    let file_name = path
+pub fn load_file_from_path(path_str: String) -> Result<(String, String, String), String> {
+    let path_buf = PathBuf::from(&path_str);
+
+    let file_name = path_buf
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("Unknown")
         .to_string();
 
-    let content = get_file_content(path).unwrap_or(String::from(""));
+    let content = read_to_string(&path_buf).map_err(|e| e.to_string())?;
 
-    // Store the state of the file.
-    let state = app.state::<Mutex<AppData>>();
-    let mut data = state.lock().unwrap();
-
-    let hash = compute_hash(&content);
-    data.opened_files.push((path_buf.clone(), hash));
-
-    Ok((file_name, path.to_str().unwrap().to_string(), content))
+    Ok((file_name, path_str, content))
 }
 
-fn get_file_content(path: &Path) -> Option<String> {
-    match read_to_string(&path) {
-        Ok(content) => Some(content),
-        Err(e) => {
-            eprintln!("Failed to load file: {}", e);
-            None
-        }
-    }
-}
-
-/// Set the project directory path (called from frontend after folder selection)
+/// Set the project directory path
 #[tauri::command]
 pub fn set_project_directory(app: AppHandle, directory_path: String) -> Result<(), String> {
-    let path_buf = PathBuf::from(directory_path.clone());
+    app.emit("folder-selected", &directory_path)
+        .map_err(|e| e.to_string())?;
 
-    println!("Set project folder: {}", path_buf.display());
-    let state = app.state::<Mutex<AppData>>();
-    let mut data = state.lock().unwrap();
-    data.project_path = Some(path_buf);
-    app.emit("folder-selected", directory_path).unwrap();
     Ok(())
 }
 
+/// Read directory contents and return tuples of (path, is_directory)
 #[tauri::command]
 pub fn read_directory_contents(path: String) -> Result<Vec<(String, bool)>, String> {
-    let paths = match read_dir(&path) {
-        Ok(paths) => paths,
-        Err(e) => return Err(format!("Error reading directory: {}", e)),
-    };
+    let entries = read_dir(&path).map_err(|e| format!("Error reading directory: {}", e))?;
 
     let mut contents = Vec::new();
-    for entry in paths {
+    for entry in entries {
         if let Ok(entry) = entry {
             let path = entry.path();
             let is_dir = path.is_dir();
@@ -129,17 +71,20 @@ pub fn read_directory_contents(path: String) -> Result<Vec<(String, bool)>, Stri
     Ok(contents)
 }
 
+/// Check if file content differs from what's on disk using hash comparison
+/// Normalizes line endings to LF for consistent comparison across platforms
 #[tauri::command]
-pub fn is_dirty(app: AppHandle, path: String, current_content: String) -> bool {
-    let path_buf = PathBuf::from(&path);
-
+pub fn is_dirty(path: String, current_content: String) -> bool {
     // Read the actual file content from disk
-    let disk_content = get_file_content(&path_buf).unwrap_or_default();
+    let disk_content = match read_to_string(&path) {
+        Ok(content) => content,
+        Err(_) => return true, // If we can't read the file, consider it dirty
+    };
 
-    // Compute hashes
+    // Compute hashes with normalized line endings
     let current_hash = compute_hash(&current_content);
     let disk_hash = compute_hash(&disk_content);
 
-    // File is dirty if current content differs from what's on disk
+    // File is dirty if hashes differ
     current_hash != disk_hash
 }

--- a/src-tauri/src/modules/file_operations.rs
+++ b/src-tauri/src/modules/file_operations.rs
@@ -2,7 +2,6 @@
 
 use std::fs::{read_dir, read_to_string, write};
 use std::path::{Path, PathBuf};
-use serde::Serialize;
 use std::sync::Mutex;
 use tauri::{AppHandle, Emitter, Manager};
 use tauri_plugin_dialog::{DialogExt, FilePath};
@@ -77,14 +76,14 @@ fn save_file_path(file_content: String, path_str: String) -> Result<String, Stri
 /// 
 /// Tauri command allows optionally path if path is passed, function will invoke load_path(), otherwise load_dialog()
 #[tauri::command]
-pub fn load_file(app: AppHandle, path: Option<String>) -> Result<(String, String), String> {
+pub fn load_file(app: AppHandle, path: Option<String>) -> Result<(String, String, String), String> {
     return if path.is_none() { load_dialog(app) } else { load_path(path.unwrap()) }
 }
 
 /// Open Tauri Dialog and load file content from it.
 /// 
 /// Using Tauri Dialog Plugin to allows user to pick the file from any user's machine to load contents from.
-fn load_dialog(app: AppHandle) -> Result<(String, String), String> {
+fn load_dialog(app: AppHandle) -> Result<(String, String, String), String> {
     let file_path = match app
         .dialog()
         .file()
@@ -107,13 +106,13 @@ fn load_dialog(app: AppHandle) -> Result<(String, String), String> {
     
     let content = get_file_content(path).unwrap_or(String::from(""));
     
-    Ok((file_name, content))
+    Ok((file_name, path.to_str().unwrap().to_string(), content))
 }
 
 /// Load file form path
 /// 
 /// This function get use path string to get the file content from specified path
-fn load_path(path_str: String) -> Result<(String, String), String> {
+fn load_path(path_str: String) -> Result<(String, String, String), String> {
     
     let path_buf = PathBuf::from(path_str);
     let path =  path_buf.as_path();
@@ -125,7 +124,7 @@ fn load_path(path_str: String) -> Result<(String, String), String> {
 
     let content = get_file_content(path).unwrap_or(String::from(""));
 
-    Ok((file_name, content))
+    Ok((file_name, path.to_str().unwrap().to_string(), content))
 }
 
 fn get_file_content(path: &Path) -> Option<String> {

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -6,5 +6,5 @@ use std::path::PathBuf;
 
 pub struct AppData {
     pub project_path: Option<PathBuf>,
-    pub open_files: Vec<(PathBuf, String)> //Store Path of file and String of contents, to determine if the file is changed by other application/process.
+    pub opened_files: Vec<(PathBuf, String)> //Store Path of file and Hashes of contents, to determine if the file is changed by other application/process.
 }

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -5,5 +5,6 @@ pub mod file_operations;
 use std::path::PathBuf;
 
 pub struct AppData {
-    pub project_path: Option<PathBuf>
+    pub project_path: Option<PathBuf>,
+    pub open_files: Vec<(PathBuf, String)> //Store Path of file and String of contents, to determine if the file is changed by other application/process.
 }

--- a/src-tauri/src/modules/mod.rs
+++ b/src-tauri/src/modules/mod.rs
@@ -1,10 +1,8 @@
 pub mod file_operations;
 
-
-// Store application state
 use std::path::PathBuf;
 
+/// Application state
 pub struct AppData {
     pub project_path: Option<PathBuf>,
-    pub opened_files: Vec<(PathBuf, String)> //Store Path of file and Hashes of contents, to determine if the file is changed by other application/process.
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "com.yast.txt-editor-rs",
   "build": {
-    "beforeDevCommand": "bun run dev",
+    "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "bun run build",
+    "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },
   "app": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,23 +5,24 @@ import EditArea from "./components/EditArea";
 import React, { useState, useEffect } from "react";
 import path from "path-browserify";
 
-// Define the type for directory contents: [fullPath: string, isDirectory: boolean]
+// Type definitions
 type DirContents = [string, boolean];
+
+// Constants
+const FILE_FILTERS = [
+  { name: "Text Files", extensions: ["txt"] },
+  { name: "Markdown Files", extensions: ["md", "markdown"] },
+  { name: "All Files", extensions: ["*"] },
+];
 
 /**
  * Fetches the contents of a given directory from the Rust backend.
- * @param directoryPath The full path of the directory to read.
- * @returns A promise that resolves to an array of [fullPath, isDirectory] tuples.
  */
 const fetchDirectoryContents = async (
   directoryPath: string,
 ): Promise<DirContents[]> => {
   try {
-    const contents: [string, boolean][] = await invoke(
-      "read_directory_contents",
-      { path: directoryPath },
-    );
-    return contents;
+    return await invoke("read_directory_contents", { path: directoryPath });
   } catch (error) {
     console.error(
       `Error fetching directory contents for ${directoryPath}:`,
@@ -29,6 +30,29 @@ const fetchDirectoryContents = async (
     );
     return [];
   }
+};
+
+/**
+ * Sorts directory contents with directories first, then alphabetically.
+ */
+const sortDirectoryContents = (contents: DirContents[]): DirContents[] =>
+  contents.sort((a, b) => {
+    // Directories before files
+    if (a[1] !== b[1]) return a[1] ? -1 : 1;
+    // Then sort alphabetically by basename
+    return path.basename(a[0]).localeCompare(path.basename(b[0]));
+  });
+
+/**
+ * Custom hook for managing Tauri event listeners.
+ */
+const useTauriEvent = (eventName: string, callback: (e?: any) => void) => {
+  useEffect(() => {
+    const unlistenPromise = listen(eventName, callback);
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [eventName, callback]);
 };
 
 const App: React.FC = () => {
@@ -41,49 +65,37 @@ const App: React.FC = () => {
   const [filePath, setFilePath] = useState("");
   const [fileContent, setFileContent] = useState("");
 
-  async function saveFile() {
+  // Save file
+  const saveFile = async () => {
     try {
       if (filePath.trim() === "") {
-        // Use frontend dialog for save
         const selectedPath = await save({
           defaultPath: "untitled.txt",
-          filters: [
-            { name: "Text Files", extensions: ["txt"] },
-            { name: "Markdown Files", extensions: ["md", "markdown"] },
-            { name: "All Files", extensions: ["*"] },
-          ],
+          filters: FILE_FILTERS,
         });
 
         if (selectedPath) {
-          const result = await invoke("save_file_to_path", {
-            fileContent: fileContent,
+          await invoke("save_file_to_path", {
+            fileContent,
             filePath: selectedPath,
           });
-          console.log(result);
           setFilePath(selectedPath);
         }
       } else {
-        const result = await invoke("save_file_to_path", {
-          fileContent: fileContent,
-          filePath: filePath,
-        });
-        console.log(result);
+        await invoke("save_file_to_path", { fileContent, filePath });
       }
     } catch (error) {
       console.error("Error saving file:", error);
     }
-  }
+  };
 
-  async function openFileDialog() {
+  // Open file dialog
+  const openFileDialog = async () => {
     try {
       const selectedPath = await open({
         multiple: false,
         directory: false,
-        filters: [
-          { name: "Text Files", extensions: ["txt"] },
-          { name: "Markdown Files", extensions: ["md", "markdown"] },
-          { name: "All Files", extensions: ["*"] },
-        ],
+        filters: FILE_FILTERS,
       });
 
       if (selectedPath) {
@@ -92,7 +104,9 @@ const App: React.FC = () => {
           : selectedPath;
         const file: [string, string, string] = await invoke(
           "load_file_from_path",
-          { pathStr },
+          {
+            pathStr,
+          },
         );
         setFilePath(file[1]);
         setFileContent(file[2]);
@@ -100,9 +114,10 @@ const App: React.FC = () => {
     } catch (error) {
       console.error("Error opening file:", error);
     }
-  }
+  };
 
-  async function openFolderDialog() {
+  // Open folder dialog
+  const openFolderDialog = async () => {
     try {
       const selectedPath = await open({
         multiple: false,
@@ -118,150 +133,60 @@ const App: React.FC = () => {
     } catch (error) {
       console.error("Error opening folder:", error);
     }
-  }
+  };
 
-  // Effect to load initial directory contents when the originPath changes
-  useEffect(() => {
-    if (originPath) {
-      fetchDirectoryContents(originPath).then((contents) => {
-        const sortedContents = contents.sort((a, b) => {
-          // If 'a' is a directory and 'b' is a file, 'a' comes first
-          if (a[1] && !b[1]) return -1;
-          // If 'a' is a file and 'b' is a directory, 'b' comes first
-          if (!a[1] && b[1]) return 1;
-          // Otherwise, sort alphabetically by their base name
-          return path.basename(a[0]).localeCompare(path.basename(b[0]));
-        });
-        setDirectoryContents(sortedContents);
-        setExpandedPaths(new Set());
-        setExpandedContents({});
-      });
-    }
-  }, [originPath]);
-
-  useEffect(() => {
-    const unlisten = listen<string>("folder-selected", (e) => {
-      setOriginPath(e.payload);
-    });
-    return () => {
-      unlisten.then((f) => f());
-    };
-  }, []);
-
-  useEffect(() => {
-    const unlisten = listen("save", () => {
-      saveFile();
-    });
-    return () => {
-      unlisten.then((f) => f());
-    };
-  }, [fileContent, filePath]);
-
-  useEffect(() => {
-    const unlisten = listen("open-file-dialog", () => {
-      openFileDialog();
-    });
-    return () => {
-      unlisten.then((f) => f());
-    };
-  }, []);
-
-  useEffect(() => {
-    const unlisten = listen("open-folder-dialog", () => {
-      openFolderDialog();
-    });
-    return () => {
-      unlisten.then((f) => f());
-    };
-  }, []);
-
-  /**
-   * Handles the click event for toggling (expanding/collapsing) a directory.
-   * @param fullPath The full path of the item that was clicked.
-   * @param isDirectory A boolean indicating if the clicked item is a directory.
-   */
+  // Handle directory tree item click
   const handleToggleFolder = async (fullPath: string, isDirectory: boolean) => {
     if (!isDirectory) {
-      console.log(`Clicked on file: ${fullPath}`);
-      let file: [string, string, string] = await invoke("load_file_from_path", {
-        pathStr: fullPath,
-      });
-      console.log(file);
+      const file: [string, string, string] = await invoke(
+        "load_file_from_path",
+        {
+          pathStr: fullPath,
+        },
+      );
       setFilePath(file[1]);
       setFileContent(file[2]);
       return;
     }
 
-    // Check if the directory is currently expanded
     if (expandedPaths.has(fullPath)) {
-      // If expanded, collapse it by removing its path from the expandedPaths set
       setExpandedPaths((prev) => {
         const newSet = new Set(prev);
         newSet.delete(fullPath);
         return newSet;
       });
     } else {
-      // If not expanded, fetch its contents
       const subcontents = await fetchDirectoryContents(fullPath);
-      const sortedSubcontents = subcontents.sort((a, b) => {
-        if (a[1] && !b[1]) return -1;
-        if (!a[1] && b[1]) return 1;
-        return path.basename(a[0]).localeCompare(path.basename(b[0]));
-      });
-
-      // Store the fetched contents in expandedContents, keyed by the directory's full path
       setExpandedContents((prev) => ({
         ...prev,
-        [fullPath]: sortedSubcontents,
+        [fullPath]: sortDirectoryContents(subcontents),
       }));
-      // Add the directory's full path to the expandedPaths set
       setExpandedPaths((prev) => new Set(prev).add(fullPath));
     }
   };
 
-  /**
-   * Recursive function to render the directory contents as a tree.
-   * @param contents An array of DirContents to render.
-   */
+  // Render directory tree recursively
   const renderDirectoryContents = (contents: DirContents[]) => (
-    // Add left padding to create indentation for nested levels
     <ul className="pl-4">
       {contents.map((item) => {
-        const itemFullPath = item[0];
-        const isDirectory = item[1];
-
-        let displayName = itemFullPath;
-        const lastSlashIndex = itemFullPath.lastIndexOf("/");
-        const lastBackslashIndex = itemFullPath.lastIndexOf("\\");
-
-        const lastSeparatorIndex = Math.max(lastSlashIndex, lastBackslashIndex);
-
-        if (lastSeparatorIndex !== -1) {
-          displayName = itemFullPath.substring(lastSeparatorIndex + 1);
-        }
+        const [itemFullPath, isDirectory] = item;
+        const displayName = itemFullPath.split(/[\\\/]/).pop() || itemFullPath;
 
         return (
-          // Use the full path as the key for uniqueness in React lists
           <li key={itemFullPath} className="py-1">
             <span
-              // Apply cursor and text color based on whether it's a directory
-              className={`cursor-pointer ${isDirectory ? "text-blue-600" : "text-gray-800"} hover:text-blue-800 flex items-center`}
-              // Call handleToggleFolder with the item's full path and type
+              className={`cursor-pointer ${
+                isDirectory ? "text-blue-600" : "text-gray-800"
+              } hover:text-blue-800 flex items-center`}
               onClick={() => handleToggleFolder(itemFullPath, isDirectory)}
             >
-              {/* Display expand/collapse icon for directories, or a file icon for files */}
-              {isDirectory ? (
-                expandedPaths.has(itemFullPath) ? (
-                  "▼ "
-                ) : (
-                  "▶ "
-                )
-              ) : (
-                <span className="mr-1">📄</span> // File icon
-              )}
+              {isDirectory
+                ? expandedPaths.has(itemFullPath)
+                  ? "▼ "
+                  : "▶ "
+                : "📄 "}
               {displayName}
             </span>
-            {/* Recursively render sub-contents if it's a directory, expanded, and has contents */}
             {isDirectory &&
               expandedPaths.has(itemFullPath) &&
               expandedContents[itemFullPath] &&
@@ -272,9 +197,25 @@ const App: React.FC = () => {
     </ul>
   );
 
+  // Load directory contents when project path changes
+  useEffect(() => {
+    if (originPath) {
+      fetchDirectoryContents(originPath).then((contents) => {
+        setDirectoryContents(sortDirectoryContents(contents));
+        setExpandedPaths(new Set());
+        setExpandedContents({});
+      });
+    }
+  }, [originPath]);
+
+  // Register event listeners
+  useTauriEvent("folder-selected", (e: any) => setOriginPath(e.payload));
+  useTauriEvent("save", () => saveFile());
+  useTauriEvent("open-file-dialog", () => openFileDialog());
+  useTauriEvent("open-folder-dialog", () => openFolderDialog());
+
   return (
     <div className="flex h-screen bg-gray-100 font-inter">
-      {/* Sidebar for the directory tree */}
       <div className="w-1/4 bg-white p-4 shadow-md overflow-auto">
         <h2 className="text-xl font-semibold mb-4 text-gray-700">
           Project Explorer
@@ -297,7 +238,6 @@ const App: React.FC = () => {
       <div className="flex-1">
         <EditArea
           filePath={filePath}
-          originPath={originPath}
           content={fileContent}
           setContent={setFileContent}
         />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ const App: React.FC = () => {
   >({});
   const [filePath, setFilePath] = useState("");
   const [fileContent, setFileContent] = useState("");
+  const [lastSavedContent, setLastSavedContent] = useState("");
 
   async function saveFile() {
     try {
@@ -61,6 +62,7 @@ const App: React.FC = () => {
           });
           console.log(result);
           setFilePath(selectedPath);
+          setLastSavedContent(fileContent);
         }
       } else {
         const result = await invoke("save_file_to_path", {
@@ -68,6 +70,7 @@ const App: React.FC = () => {
           filePath: filePath,
         });
         console.log(result);
+        setLastSavedContent(fileContent);
       }
     } catch (error) {
       console.error("Error saving file:", error);
@@ -96,6 +99,7 @@ const App: React.FC = () => {
         );
         setFilePath(file[1]);
         setFileContent(file[2]);
+        setLastSavedContent(file[2]);
       }
     } catch (error) {
       console.error("Error opening file:", error);
@@ -189,6 +193,7 @@ const App: React.FC = () => {
       console.log(file);
       setFilePath(file[1]);
       setFileContent(file[2]);
+      setLastSavedContent(file[2]);
       return;
     }
 
@@ -300,6 +305,7 @@ const App: React.FC = () => {
           originPath={originPath}
           content={fileContent}
           setContent={setFileContent}
+          lastSavedContent={lastSavedContent}
         />
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { open, save } from "@tauri-apps/plugin-dialog";
 import EditArea from "./components/EditArea";
 import React, { useState, useEffect } from "react";
-import path from 'path-browserify'; 
+import path from "path-browserify";
 
 // Define the type for directory contents: [fullPath: string, isDirectory: boolean]
 type DirContents = [string, boolean];
@@ -12,12 +13,20 @@ type DirContents = [string, boolean];
  * @param directoryPath The full path of the directory to read.
  * @returns A promise that resolves to an array of [fullPath, isDirectory] tuples.
  */
-const fetchDirectoryContents = async (directoryPath: string): Promise<DirContents[]> => {
+const fetchDirectoryContents = async (
+  directoryPath: string,
+): Promise<DirContents[]> => {
   try {
-    const contents: [string, boolean][] = await invoke("read_directory_contents", { path: directoryPath });
+    const contents: [string, boolean][] = await invoke(
+      "read_directory_contents",
+      { path: directoryPath },
+    );
     return contents;
   } catch (error) {
-    console.error(`Error fetching directory contents for ${directoryPath}:`, error);
+    console.error(
+      `Error fetching directory contents for ${directoryPath}:`,
+      error,
+    );
     return [];
   }
 };
@@ -26,16 +35,88 @@ const App: React.FC = () => {
   const [originPath, setOriginPath] = useState("");
   const [directoryContents, setDirectoryContents] = useState<DirContents[]>([]);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
-  const [expandedContents, setExpandedContents] = useState<Record<string, DirContents[]>>({});
-  const [filePath, setFilePath] = useState('');
-  const [fileContent, setFileContent] = useState('');
+  const [expandedContents, setExpandedContents] = useState<
+    Record<string, DirContents[]>
+  >({});
+  const [filePath, setFilePath] = useState("");
+  const [fileContent, setFileContent] = useState("");
 
-  function save() {
-    if (filePath.trim() === '') {
-      invoke("save_file", {fileContent: fileContent});
-    } 
-    else {
-      invoke("save_file", {fileContent: fileContent, filePath: filePath});
+  async function saveFile() {
+    try {
+      if (filePath.trim() === "") {
+        // Use frontend dialog for save
+        const selectedPath = await save({
+          defaultPath: "untitled.txt",
+          filters: [
+            { name: "Text Files", extensions: ["txt"] },
+            { name: "Markdown Files", extensions: ["md", "markdown"] },
+            { name: "All Files", extensions: ["*"] },
+          ],
+        });
+
+        if (selectedPath) {
+          const result = await invoke("save_file_to_path", {
+            fileContent: fileContent,
+            filePath: selectedPath,
+          });
+          console.log(result);
+          setFilePath(selectedPath);
+        }
+      } else {
+        const result = await invoke("save_file_to_path", {
+          fileContent: fileContent,
+          filePath: filePath,
+        });
+        console.log(result);
+      }
+    } catch (error) {
+      console.error("Error saving file:", error);
+    }
+  }
+
+  async function openFileDialog() {
+    try {
+      const selectedPath = await open({
+        multiple: false,
+        directory: false,
+        filters: [
+          { name: "Text Files", extensions: ["txt"] },
+          { name: "Markdown Files", extensions: ["md", "markdown"] },
+          { name: "All Files", extensions: ["*"] },
+        ],
+      });
+
+      if (selectedPath) {
+        const pathStr = Array.isArray(selectedPath)
+          ? selectedPath[0]
+          : selectedPath;
+        const file: [string, string, string] = await invoke(
+          "load_file_from_path",
+          { pathStr },
+        );
+        setFilePath(file[1]);
+        setFileContent(file[2]);
+      }
+    } catch (error) {
+      console.error("Error opening file:", error);
+    }
+  }
+
+  async function openFolderDialog() {
+    try {
+      const selectedPath = await open({
+        multiple: false,
+        directory: true,
+      });
+
+      if (selectedPath) {
+        const pathStr = Array.isArray(selectedPath)
+          ? selectedPath[0]
+          : selectedPath;
+        await invoke("set_project_directory", { directoryPath: pathStr });
+      }
+    } catch (error) {
+      console.error("Error opening folder:", error);
     }
   }
 
@@ -68,13 +149,31 @@ const App: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const unlisten = listen('save', () => {
-      save()
+    const unlisten = listen("save", () => {
+      saveFile();
     });
     return () => {
       unlisten.then((f) => f());
     };
-  })
+  }, [fileContent, filePath]);
+
+  useEffect(() => {
+    const unlisten = listen("open-file-dialog", () => {
+      openFileDialog();
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
+
+  useEffect(() => {
+    const unlisten = listen("open-folder-dialog", () => {
+      openFolderDialog();
+    });
+    return () => {
+      unlisten.then((f) => f());
+    };
+  }, []);
 
   /**
    * Handles the click event for toggling (expanding/collapsing) a directory.
@@ -84,7 +183,9 @@ const App: React.FC = () => {
   const handleToggleFolder = async (fullPath: string, isDirectory: boolean) => {
     if (!isDirectory) {
       console.log(`Clicked on file: ${fullPath}`);
-      let file: [string, string, string] = await invoke("load_file", {path: fullPath});
+      let file: [string, string, string] = await invoke("load_file_from_path", {
+        pathStr: fullPath,
+      });
       console.log(file);
       setFilePath(file[1]);
       setFileContent(file[2]);
@@ -109,11 +210,13 @@ const App: React.FC = () => {
       });
 
       // Store the fetched contents in expandedContents, keyed by the directory's full path
-      setExpandedContents((prev) => ({ ...prev, [fullPath]: sortedSubcontents }));
+      setExpandedContents((prev) => ({
+        ...prev,
+        [fullPath]: sortedSubcontents,
+      }));
       // Add the directory's full path to the expandedPaths set
       setExpandedPaths((prev) => new Set(prev).add(fullPath));
     }
-
   };
 
   /**
@@ -126,10 +229,10 @@ const App: React.FC = () => {
       {contents.map((item) => {
         const itemFullPath = item[0];
         const isDirectory = item[1];
-        
+
         let displayName = itemFullPath;
-        const lastSlashIndex = itemFullPath.lastIndexOf('/');
-        const lastBackslashIndex = itemFullPath.lastIndexOf('\\');
+        const lastSlashIndex = itemFullPath.lastIndexOf("/");
+        const lastBackslashIndex = itemFullPath.lastIndexOf("\\");
 
         const lastSeparatorIndex = Math.max(lastSlashIndex, lastBackslashIndex);
 
@@ -148,16 +251,21 @@ const App: React.FC = () => {
             >
               {/* Display expand/collapse icon for directories, or a file icon for files */}
               {isDirectory ? (
-                expandedPaths.has(itemFullPath) ? "▼ " : "▶ "
+                expandedPaths.has(itemFullPath) ? (
+                  "▼ "
+                ) : (
+                  "▶ "
+                )
               ) : (
                 <span className="mr-1">📄</span> // File icon
               )}
               {displayName}
             </span>
             {/* Recursively render sub-contents if it's a directory, expanded, and has contents */}
-            {isDirectory && expandedPaths.has(itemFullPath) && expandedContents[itemFullPath] && (
-              renderDirectoryContents(expandedContents[itemFullPath])
-            )}
+            {isDirectory &&
+              expandedPaths.has(itemFullPath) &&
+              expandedContents[itemFullPath] &&
+              renderDirectoryContents(expandedContents[itemFullPath])}
           </li>
         );
       })}
@@ -168,19 +276,31 @@ const App: React.FC = () => {
     <div className="flex h-screen bg-gray-100 font-inter">
       {/* Sidebar for the directory tree */}
       <div className="w-1/4 bg-white p-4 shadow-md overflow-auto">
-        <h2 className="text-xl font-semibold mb-4 text-gray-700">Project Explorer</h2>
+        <h2 className="text-xl font-semibold mb-4 text-gray-700">
+          Project Explorer
+        </h2>
         <p className="text-sm text-gray-600 mb-2">
-          Origin Path: <span className="font-mono text-xs break-all">{originPath || "No folder selected"}</span>
+          Origin Path:{" "}
+          <span className="font-mono text-xs break-all">
+            {originPath || "No folder selected"}
+          </span>
         </p>
         {directoryContents.length > 0 ? (
           renderDirectoryContents(directoryContents)
         ) : (
-          <p className="text-gray-500 text-sm">Select a folder to view its contents.</p>
+          <p className="text-gray-500 text-sm">
+            Select a folder to view its contents.
+          </p>
         )}
       </div>
 
       <div className="flex-1">
-        <EditArea filePath={filePath} originPath={originPath} content={fileContent} setContent={setFileContent}/>
+        <EditArea
+          filePath={filePath}
+          originPath={originPath}
+          content={fileContent}
+          setContent={setFileContent}
+        />
       </div>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,6 @@ const App: React.FC = () => {
   >({});
   const [filePath, setFilePath] = useState("");
   const [fileContent, setFileContent] = useState("");
-  const [lastSavedContent, setLastSavedContent] = useState("");
 
   async function saveFile() {
     try {
@@ -62,7 +61,6 @@ const App: React.FC = () => {
           });
           console.log(result);
           setFilePath(selectedPath);
-          setLastSavedContent(fileContent);
         }
       } else {
         const result = await invoke("save_file_to_path", {
@@ -70,7 +68,6 @@ const App: React.FC = () => {
           filePath: filePath,
         });
         console.log(result);
-        setLastSavedContent(fileContent);
       }
     } catch (error) {
       console.error("Error saving file:", error);
@@ -99,7 +96,6 @@ const App: React.FC = () => {
         );
         setFilePath(file[1]);
         setFileContent(file[2]);
-        setLastSavedContent(file[2]);
       }
     } catch (error) {
       console.error("Error opening file:", error);
@@ -193,7 +189,6 @@ const App: React.FC = () => {
       console.log(file);
       setFilePath(file[1]);
       setFileContent(file[2]);
-      setLastSavedContent(file[2]);
       return;
     }
 
@@ -305,7 +300,6 @@ const App: React.FC = () => {
           originPath={originPath}
           content={fileContent}
           setContent={setFileContent}
-          lastSavedContent={lastSavedContent}
         />
       </div>
     </div>

--- a/src/components/EditArea.tsx
+++ b/src/components/EditArea.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from '@tauri-apps/api/event';
 
-function EditArea() {
-  const [content, setContent] = useState<string>('');
+interface EditAreaProps {
+  filePath: string;
+  originPath: string;
+  content: string;
+  setContent: React.Dispatch<React.SetStateAction<string>>;
+}
+
+function EditArea({ filePath, originPath, content, setContent }: EditAreaProps) {
   const [lineCount, setLineCount] = useState<number>(1);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -35,21 +39,16 @@ function EditArea() {
     return numbers;
   }, [lineCount]);
 
-  type FileLoaded = {
-    fileName: string,
-    content: string
+  const cleanFileName = () => {
+    let origin_removed = filePath.replace(originPath, '')
+    if (origin_removed === filePath) { return filePath }
+    
+    return origin_removed.substring(1, origin_removed.length);
   }
-
-  listen<FileLoaded>('file-loaded', (e) => {
-    setContent(e.payload.content)
-  })
-
-  listen<FileLoaded>('save', () => {
-    invoke("save_file", {fileContent: content})
-  })
 
   return (
     <div>
+      <span>{cleanFileName()}</span>
       <div className="flex flex-col w-full max-h-screen h-[100vh] bg-gray-800 overflow-hidden">
         {/* Editor Wrapper: Contains line numbers and textarea */}
         <div className="flex flex-1 overflow-hidden relative">

--- a/src/components/EditArea.tsx
+++ b/src/components/EditArea.tsx
@@ -1,26 +1,45 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
 
 interface EditAreaProps {
   filePath: string;
   originPath: string;
   content: string;
   setContent: React.Dispatch<React.SetStateAction<string>>;
+  lastSavedContent: string;
 }
 
-function EditArea({ filePath, originPath, content, setContent }: EditAreaProps) {
+function EditArea({
+  filePath,
+  originPath,
+  content,
+  setContent,
+  lastSavedContent,
+}: EditAreaProps) {
   const [lineCount, setLineCount] = useState<number>(1);
+  const [isDirty, setIsDirty] = useState<boolean>(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const lineNumbersRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setLineCount(content.split('\n').length);
+    setLineCount(content.split("\n").length);
   }, [content]);
 
+  // Check dirty state whenever content or lastSavedContent changes
+  useEffect(() => {
+    if (filePath) {
+      setIsDirty(content !== lastSavedContent);
+    }
+  }, [content, lastSavedContent, filePath]);
+
   // Handle changes in the textarea
-  const handleContentChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setContent(event.target.value);
-  }, []);
+  const handleContentChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setContent(event.target.value);
+    },
+    [setContent],
+  );
 
   // Synchronize scrolling between the textarea and the line numbers
   const handleScroll = useCallback(() => {
@@ -34,21 +53,46 @@ function EditArea({ filePath, originPath, content, setContent }: EditAreaProps) 
   const renderLineNumbers = useCallback(() => {
     const numbers = [];
     for (let i = 1; i <= lineCount; i++) {
-      numbers.push(<div key={i} className="line-number h-6 flex items-center justify-end pr-2">{i}</div>);
+      numbers.push(
+        <div
+          key={i}
+          className="line-number h-6 flex items-center justify-end pr-2"
+        >
+          {i}
+        </div>,
+      );
     }
     return numbers;
   }, [lineCount]);
 
   const cleanFileName = () => {
-    let origin_removed = filePath.replace(originPath, '')
-    if (origin_removed === filePath) { return filePath }
-    
+    let origin_removed = filePath.replace(originPath, "");
+    if (origin_removed === filePath) {
+      return filePath;
+    }
+
     return origin_removed.substring(1, origin_removed.length);
-  }
+  };
+
+  const getDirtyIndicator = () => {
+    return isDirty ? "●" : "";
+  };
 
   return (
     <div>
-      <span>{cleanFileName()}</span>
+      <div className="flex items-center justify-between px-4 py-2 bg-gray-50 border-b border-gray-200">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-gray-800">{cleanFileName()}</span>
+          {isDirty && (
+            <span className="text-red-500 text-lg" title="Unsaved changes">
+              {getDirtyIndicator()}
+            </span>
+          )}
+        </div>
+        <span className="text-xs text-gray-500">
+          {isDirty ? "Unsaved" : "Saved"}
+        </span>
+      </div>
       <div className="flex flex-col w-full max-h-screen h-[100vh] bg-gray-800 overflow-hidden">
         {/* Editor Wrapper: Contains line numbers and textarea */}
         <div className="flex flex-1 overflow-hidden relative">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,10 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import './App.css';
 
-window.addEventListener('contextmenu', (e) => {
-    e.preventDefault()
-  }
-)
+// window.addEventListener('contextmenu', (e) => {
+//     e.preventDefault()
+//   }
+// )
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
This pull request introduces significant improvements to file management and frontend-backend integration for a Tauri-based text editor. The main changes include refactoring file operations to use explicit file paths (with dialogs handled in the frontend), tracking file state and changes using hashes, and updating the frontend to work with the new backend API and event-driven architecture. Additionally, some dependencies and configuration files have been updated.

**File Operations Refactor and State Management**

- Refactored file operations in `file_operations.rs` to remove direct dialog usage from the backend. Instead, file open/save dialogs are now handled in the frontend, and backend commands (`save_file_to_path`, `load_file_from_path`, `set_project_directory`) operate on explicit file paths received from the frontend. File state is now tracked using hashes to detect unsaved changes or external modifications. [[1]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eR1-R68) [[2]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eL92-R86) [[3]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eR99-R113) [[4]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eR131-R145) [[5]](diffhunk://#diff-19848f76ac872c93ce509da7a03067bf972e353cc8774f9d02445e6db891f2c3L8-R9)

- Added a new `is_dirty` backend command to determine if the file content in memory differs from the version on disk, using SHA256 hashes.

**Frontend Integration and Event Handling**

- Updated `App.tsx` to handle file and folder dialogs in the frontend using Tauri's dialog plugins. The frontend now invokes backend commands with explicit file paths and listens for menu events (`save`, `open-file-dialog`, `open-folder-dialog`) to trigger the appropriate actions. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L15-R29) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L29-R121) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R151-R177) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L67-R191)

- Updated the file tree and file opening logic to use the new backend API, ensuring the UI reflects the current file state and contents. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L90-R216) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L108-R235) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L128-R268)

**Dependency and Configuration Updates**

- Added `tauri-plugin-fs` and `sha2` dependencies to `Cargo.toml` for improved file system access and hashing capabilities.

- Changed Tauri build scripts in `tauri.conf.json` to use `npm` instead of `bun` for compatibility.

**Miscellaneous Improvements**

- Cleaned up and clarified the Tauri capabilities JSON and adjusted the `README.md` to include a direct link to Tauri's Linux prerequisites. [[1]](diffhunk://#diff-8fe2bbfebcddedcaa718510825d2a4bd04f59d2826a6848ea55fa086c5bb4213L5-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R10)

- Minor code style and import fixes for consistency. [[1]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL3-R3) [[2]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL12-R54) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-R6)

**References:**  
[[1]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eR1-R68) [[2]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eL92-R86) [[3]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eR99-R113) [[4]](diffhunk://#diff-c7802c7e01209ae83a51f93f5078de9e8132cda3e8e349a898b0c16e254d0a7eR131-R145) [[5]](diffhunk://#diff-19848f76ac872c93ce509da7a03067bf972e353cc8774f9d02445e6db891f2c3L8-R9) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L15-R29) [[7]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L29-R121) [[8]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R151-R177) [[9]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L67-R191) [[10]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L90-R216) [[11]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L108-R235) [[12]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L128-R268) [[13]](diffhunk://#diff-fe4c6a80a21e81339e2e0faeb9134d0f9636c168987df13c8abf1927a1caee39L26-R27) [[14]](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L7-R9) [[15]](diffhunk://#diff-8fe2bbfebcddedcaa718510825d2a4bd04f59d2826a6848ea55fa086c5bb4213L5-R6) [[16]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R10) [[17]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL3-R3) [[18]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL12-R54) [[19]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L2-R6)


Author's Note: This summary was generated by Copilot. Since I forgot what was done in this branch already 😭 